### PR TITLE
3.4.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.2
 
 RUN apk --update add python py-pip && \
-    pip install elasticsearch-curator==3.3.0
+    pip install elasticsearch-curator==3.4.0
 
 ENTRYPOINT ["/usr/bin/curator"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ resulting in a just 50mb image.
 Image entrypoint is set to curator script, so just run the image:
 
 ```
-docker run --rm bobrik/curator:3.3.0 --help
+docker run --rm bobrik/curator:3.4.0 --help
 ```
 
 Pick whatever version you need.


### PR DESCRIPTION
Update to curator 3.4.0 with support for Elasticsearch 2.0. 

See release notes for more information:
https://github.com/elastic/curator/releases/tag/v3.4.0
https://github.com/elastic/curator/releases/tag/v3.4.0.rc1
