### PR TITLE
Remove pip and apk cache in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:3.2
 
 RUN apk --update add python py-pip && \
-    pip install elasticsearch-curator==3.4.0
+    pip install elasticsearch-curator==3.4.0 && \
+    apk del py-pip && \
+    rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["/usr/bin/curator"]


### PR DESCRIPTION
Reduce the footprint of this repository even further
(from ~50MiB to ~43MiB) by removing pip and the apk cache
at the end of the build.
