### PR TITLE
Update curator to v3.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.3
 
 RUN apk --update add python py-pip && \
-    pip install elasticsearch-curator==3.5.0 && \
+    pip install elasticsearch-curator==3.5.1 && \
     apk del py-pip && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Version 3.5.1 was released on March 21, 2016 with three fixes:
https://github.com/elastic/curator/releases/tag/v3.5.1
