### PR TITLE
Update curator to 4.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
-RUN apk --update add python py-pip && \
-    pip install elasticsearch-curator==3.5.1 && \
+RUN apk --update add python py-setuptools py-pip && \
+    pip install elasticsearch-curator==4.0.1 && \
     apk del py-pip && \
     rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ resulting in a just 50mb image.
 Image entrypoint is set to curator script, so just run the image:
 
 ```
-docker run --rm bobrik/curator:3.4.0 --help
+docker run --rm bobrik/curator:4.0.1 --help
 ```
 
 Pick whatever version you need.


### PR DESCRIPTION
Updates curator to 4.0.1.

Also had to update to explicity install `py-setuptools` as it was being uninstalled with `py-pip` previously.

4.x seems to require `pkg_resources` (part of `py-setuptools`), as when I only bumped the version, I encountered this error:

```
$ docker run --rm curator --help
Traceback (most recent call last):
  File "/usr/bin/curator", line 5, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
```

Regardless, there is little impact to the final image size. `latest` is currently at `45.34 MB` and the one I built locally with these changes rolls in at `47.44 MB`.
