### PR TITLE
Update curator to 4.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.4
 
 RUN apk --update add python py-setuptools py-pip && \
-    pip install elasticsearch-curator==4.0.1 && \
+    pip install elasticsearch-curator==4.0.3 && \
     apk del py-pip && \
     rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ resulting in a just 50mb image.
 Image entrypoint is set to curator script, so just run the image:
 
 ```
-docker run --rm bobrik/curator:4.0.1 --help
+docker run --rm bobrik/curator:4.0.3 --help
 ```
 
 Pick whatever version you need.


### PR DESCRIPTION
This PR updates curator to 4.0.3 which was released on 22 July 2016.
