### PR TITLE
Include requests-aws4auth in image for AWS ES support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.4
 
 RUN apk --update add python py-setuptools py-pip && \
     pip install elasticsearch-curator==5.1.1 && \
+    pip install requests-aws4auth && \
     apk del py-pip && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
The aws_key client option doesn't work unless requests-aws4auth is manually installed: https://www.elastic.co/guide/en/elasticsearch/client/curator/current/configfile.html#aws_key

For some reason it's not a default transitive dependency of elasticsearch-curator and we have to install it manually in the Docker build process.
