### PR TITLE
Enhanced to use openssl for Search guard cert support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM alpine:3.6
 
-RUN apk --no-cache add python py-setuptools py-pip && \
+RUN apk --no-cache add python py-setuptools py-pip gcc libffi py-cffi python-dev libffi-dev py-openssl musl-dev linux-headers openssl-dev && \
     pip install elasticsearch-curator==5.4.0 && \
-    pip install boto3 && \
-    pip install requests-aws4auth && \
-    apk del py-pip
+    pip install requests-aws4auth==0.9 && \
+    pip install cryptography==2.1.3 && \
+    apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers openssl-dev && \
+    sed -i '/import sys/a urllib3.contrib.pyopenssl.inject_into_urllib3()' /usr/bin/curator && \
+    sed -i '/import sys/a import urllib3.contrib.pyopenssl' /usr/bin/curator && \
+    sed -i '/import sys/a import urllib3' /usr/bin/curator
 
 USER nobody:nobody
+
 ENTRYPOINT ["/usr/bin/curator"]


### PR DESCRIPTION
## Background:

Curator, when run against an ElasticSearch cluster with Search Guard SSL enabled using `ssl_no_validate: False` fails with:

```
2017-11-10 19:00:12,407 INFO      Preparing Action ID: 1, "delete_indices"
Traceback (most recent call last):
  File "/usr/bin/curator", line 9, in <module>
    load_entry_point('elasticsearch-curator==5.2.0', 'console_scripts', 'curator')()
  File "/usr/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/curator/cli.py", line 211, in cli
    run(config, action_file, dry_run)
  File "/usr/lib/python2.7/site-packages/curator/cli.py", line 158, in run
    client = get_client(**client_args)
  File "/usr/lib/python2.7/site-packages/curator/utils.py", line 800, in get_client
    'Error: {0}'.format(e)
elasticsearch.exceptions.ElasticsearchException: Unable to create client connection to Elasticsearch.  Error: ConnectionError(error return without exception set) caused by: SystemError(error return without exception set)
```

## Motivation

Running without SSL verification worked for Basic Auth for me, but not with private/public key pairs. Regardless of authenticating method, I would like to have SSL verification enabled.

## Notes re: my solution

This TLS problem has been discussed at length on Search Guard and Curator's repo pages and concluded in being a won't-fix-but-will-accept-PR from curator core because it only affects Search Guard and not X-Pack's TLS. Additionally, it was discovered the problem is from Python's TLS mechanisms and not TLS, Curator, or SG proper. A fix for Python's TLS is described at https://gist.github.com/floragunncom/9319a994ae09df64b2a173128f745ed2.

I have converted these described changes to Alpine Linux and using these code changes on top of docker-curator I am able to run not only with Basic Auth with `ssl_no_validate: False` but also with the key/cert pair! :)

Switching back to the current master version returns it to the original error, so I feel fairly confident I am following the right approach and would love your feedback on how to improve it further to the point where you feel comfortable incorporating upstream.

## Additional Note

Additionally some SSL failures are now more explicit, for example, the above "error return without exception set" became:

```
elasticsearch.exceptions.ElasticsearchException: Unable to create client connection to Elasticsearch.  Error: ConnectionError(The label * is not a valid A-label) caused by: IDNAError(The label * is not a valid A-label)
``` 

And was fixed after removing one of the Subject Alternative Names with a asterisk wildcard. This sensitivity of Python's SSL is also documented elsewhere on the net, e.g. curl and browsers had no problem with that same keypair, with or without the wildcard SAN but Python required it to be removed.

