### PR TITLE
bump alpine version, switch to --no-cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
-RUN apk --update add python py-setuptools py-pip && \
+RUN apk --no-cache add python py-setuptools py-pip && \
     pip install elasticsearch-curator==5.2.0 && \
     pip install requests-aws4auth && \
-    apk del py-pip && \
-    rm -rf /var/cache/apk/*
+    apk del py-pip 
 
 USER nobody:nobody
 ENTRYPOINT ["/usr/bin/curator"]


### PR DESCRIPTION
You can use the --no-cache option to apk, then you don't have to delete the package cache afterwards.

All the best,

Benjamin