### PR TITLE
Install boto3 to add support for environment credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.4
 
 RUN apk --update add python py-setuptools py-pip && \
     pip install elasticsearch-curator==5.4.0 && \
+    pip install boto3 && \
     pip install requests-aws4auth && \
     apk del py-pip && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Support for AWS credentials was updated in https://github.com/elastic/curator/pull/1084 in curator >=5.3.0.

Updates https://github.com/bobrik/docker-curator/pull/19.