### PR TITLE
Fixed Search Guard Cert Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.6
 
-RUN apk --no-cache add python py-setuptools py-pip gcc libffi py-cffi python-dev libffi-dev py-openssl musl-dev linux-headers openssl-dev && \
+RUN apk --no-cache add python py-setuptools py-pip gcc libffi py-cffi python-dev libffi-dev py-openssl musl-dev linux-headers openssl-dev libssl1.0 && \
     pip install elasticsearch-curator==5.4.0 && \
     pip install requests-aws4auth==0.9 && \
     pip install cryptography==2.1.3 && \
-    apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers && \
+    apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers openssl-dev && \
     sed -i '/import sys/a urllib3.contrib.pyopenssl.inject_into_urllib3()' /usr/bin/curator && \
     sed -i '/import sys/a import urllib3.contrib.pyopenssl' /usr/bin/curator && \
     sed -i '/import sys/a import urllib3' /usr/bin/curator

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6
 
 RUN apk --no-cache add python py-setuptools py-pip gcc libffi py-cffi python-dev libffi-dev py-openssl musl-dev linux-headers openssl-dev libssl1.0 && \
     pip install elasticsearch-curator==5.4.0 && \
-    pip install boto3 && \
+    pip install boto3==1.4.8 && \
     pip install requests-aws4auth==0.9 && \
     pip install cryptography==2.1.3 && \
     apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers openssl-dev && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add python py-setuptools py-pip gcc libffi py-cffi python-dev
     pip install elasticsearch-curator==5.4.0 && \
     pip install requests-aws4auth==0.9 && \
     pip install cryptography==2.1.3 && \
-    apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers openssl-dev && \
+    apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers && \
     sed -i '/import sys/a urllib3.contrib.pyopenssl.inject_into_urllib3()' /usr/bin/curator && \
     sed -i '/import sys/a import urllib3.contrib.pyopenssl' /usr/bin/curator && \
     sed -i '/import sys/a import urllib3' /usr/bin/curator


### PR DESCRIPTION
# Background:

When https://github.com/bobrik/docker-curator/pull/22 was merged it caused problems for many end users in #27 and was reverted. The problem encountered was not reproducible on my original image, so I recreated from the rebased version and ran into the same problem immediately.

After some tracing back I found my version was built on alpine 3.4 base image, while we are now building on alpine 3.6 (the rebase maybe?). After re-building fresh from both and comparing I noticed some interesting differences around libssl.

Anyway I was able to fix it by no longer removing `openssl-dev`. I did not extensively test it but my test container starts up properly, so please someone give it a shot so we can get this available for everyone :)

## 3.4 Build output snippets

libssl was already installed on 3.4:

```
Step 2 : RUN apk --update add python py-setuptools py-pip gcc libffi py-cffi python-dev libffi-dev py-openssl musl-dev linux-headers openssl-dev &&     pip install elasticsearch-curator==5.2.0 &&     pip install requests-aws4auth==0.9 &&     pip install cryptography==2.1.3 &&     apk del py-pip gcc python-dev libffi-dev musl-dev linux-headers openssl-dev &&     rm -rf /var/cache/apk/*
 ---> Running in dc62702bffe2
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/36) Upgrading libcrypto1.0 (1.0.2k-r0 -> 1.0.2m-r0)
(2/36) Upgrading libssl1.0 (1.0.2k-r0 -> 1.0.2m-r0)
```

Crypto installs cleanly

```
You are using pip version 8.1.2, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting cryptography==2.1.3
  Downloading cryptography-2.1.3.tar.gz (441kB)
Requirement already satisfied (use --upgrade to upgrade): idna>=2.1 in /usr/lib/python2.7/site-packages (from cryptography==2.1.3)
Collecting asn1crypto>=0.21.0 (from cryptography==2.1.3)
  Downloading asn1crypto-0.23.0-py2.py3-none-any.whl (99kB)
Collecting six>=1.4.1 (from cryptography==2.1.3)
  Downloading six-1.11.0-py2.py3-none-any.whl
Collecting cffi>=1.7 (from cryptography==2.1.3)
  Downloading cffi-1.11.2.tar.gz (435kB)
Collecting enum34 (from cryptography==2.1.3)
  Downloading enum34-1.1.6-py2-none-any.whl
Collecting ipaddress (from cryptography==2.1.3)
  Downloading ipaddress-1.0.18-py2-none-any.whl
Requirement already satisfied (use --upgrade to upgrade): pycparser in /usr/lib/python2.7/site-packages (from cffi>=1.7->cryptography==2.1.3)
Installing collected packages: asn1crypto, six, cffi, enum34, ipaddress, cryptography
  Found existing installation: cffi 1.4.2
    Uninstalling cffi-1.4.2:
      Successfully uninstalled cffi-1.4.2
  Running setup.py install for cffi: started
    Running setup.py install for cffi: finished with status 'done'
  Running setup.py install for cryptography: started
    Running setup.py install for cryptography: finished with status 'done'
Successfully installed asn1crypto-0.23.0 cffi-1.11.2 cryptography-2.1.3 enum34-1.1.6 ipaddress-1.0.18 six-1.11.0
```

and purging openssl-dev does not include libssl:

```
(8/20) Purging openssl-dev (1.0.2m-r0)
(9/20) Purging zlib-dev (1.2.11-r0)
(10/20) Purging py-pip (8.1.2-r0)
```

## 3.6 Build output snippets

libssl is not upgraded, but installed:

```
(1/53) Upgrading musl (1.1.16-r10 -> 1.1.16-r14)
(2/53) Installing binutils-libs (2.28-r3)
...
(17/53) Installing linux-headers (4.4.6-r2)
(18/53) Installing musl-dev (1.1.16-r14)
(19/53) Installing zlib-dev (1.2.11-r0)
(20/53) Installing libcrypto1.0 (1.0.2m-r0)
(21/53) Installing libssl1.0 (1.0.2m-r0)
(22/53) Installing openssl-dev (1.0.2m-r0)
```

(also notice that it *is installed just before openssl-dev now*)

crypto is different and an older version seems to now be installed and need removal first:

```
Collecting cryptography==2.1.3
  Downloading cryptography-2.1.3.tar.gz (441kB)
Requirement already satisfied: idna>=2.1 in /usr/lib/python2.7/site-packages (from cryptography==2.1.3)
Requirement already satisfied: asn1crypto>=0.21.0 in /usr/lib/python2.7/site-packages (from cryptography==2.1.3)
Requirement already satisfied: six>=1.4.1 in /usr/lib/python2.7/site-packages (from cryptography==2.1.3)
Requirement already satisfied: cffi>=1.7 in /usr/lib/python2.7/site-packages (from cryptography==2.1.3)
Requirement already satisfied: enum34 in /usr/lib/python2.7/site-packages (from cryptography==2.1.3)
Requirement already satisfied: ipaddress in /usr/lib/python2.7/site-packages (from cryptography==2.1.3)
Requirement already satisfied: pycparser in /usr/lib/python2.7/site-packages (from cffi>=1.7->cryptography==2.1.3)
Installing collected packages: cryptography
  Found existing installation: cryptography 1.8.1
    Uninstalling cryptography-1.8.1:
      Successfully uninstalled cryptography-1.8.1
  Running setup.py install for cryptography: started
    Running setup.py install for cryptography: finished with status 'done'
Successfully installed cryptography-2.1.3
```

And most gravely, purging openssl-dev removes libssl:

```
(7/21) Purging musl-dev (1.1.16-r14)
(8/21) Purging openssl-dev (1.0.2m-r0)
(9/21) Purging zlib-dev (1.2.11-r0)
(10/21) Purging libssl1.0 (1.0.2m-r0)
(11/21) Purging py2-pip (9.0.1-r1)
```

# Conclusion

So I removed the removal of openssl-dev as in alpine 3.6 it causes libssl to be removed.

Now as I am putting this PR together I am thinking if I pull in libssl1.0 directly we can still purge openssl-dev so I will try that and push up a follow up commit if it works.

(edit:) Adding libssl1.0 as a dependency definitely prevents it from being removed. I cannot remove openssl-dev itself as it is needed for pip's cryptography install. Seems a happy medium!

(edit2:) I saw the conflict, it was around boto3 so I brought it in. I also unpinned my additions to see if there were new versions that got installed in 3.6 but they were the same. I pinned boto3 where it installed at. I noticed that cryptography did not install at all so I am guessing that pre-existing 1.8 one would be used in that case. At this moment it is late at night and I cannot recall if I had pinned the versions to be "proper" or if 2.1.3 of crypto was considered needed. Both ways start successfully on my local test container without running into the libssl error. I am erring in the side of 2.1.3 being newer and better, but please if anyone knows which let me know and I'll switch to either.

edit2 tl;dr I think we can safely unpin versions if you would rather leave them unpinned, but I have not extensively tested using search guard with the older version of crypto that python/pip on alpine 3.6 seems to come with.